### PR TITLE
Removed useEffect in useKeycloak

### DIFF
--- a/src/shared/hooks/useKeycloak.js
+++ b/src/shared/hooks/useKeycloak.js
@@ -8,39 +8,32 @@ const useKeycloak = () => {
 
   const { autoRefreshToken } = auth;
 
-  useEffect(() => {
-    keycloak.onAuthSuccess = () => {
-      autoRefreshToken(true);
-      setAuthenticatied(true);
-      const { roles } = keycloak.realmAccess || [];
-      setCanEdit(roles.includes('bs_all'));
-      setCanAdd(roles.includes('bs_all'));
-    };
-    keycloak.onAuthError = () => {
-      autoRefreshToken(false);
-      setAuthenticatied(false);
-      setCanAdd(false);
-      setCanEdit(false);
-    };
-    keycloak.onAuthRefreshError = () => {
-      autoRefreshToken(false);
-      setAuthenticatied(false);
-      setCanAdd(false);
-      setCanEdit(false);
-    };
-    keycloak.onAuthRefreshSuccess = () => {
-      setAuthenticatied(true);
+  keycloak.onAuthSuccess = () => {
+    autoRefreshToken(true);
+    setAuthenticatied(true);
+    const { roles } = keycloak.realmAccess || [];
+    setCanEdit(roles.includes('bs_all'));
+    setCanAdd(roles.includes('bs_all'));
+  };
+  keycloak.onAuthError = () => {
+    autoRefreshToken(false);
+    setAuthenticatied(false);
+    setCanAdd(false);
+    setCanEdit(false);
+  };
+  keycloak.onAuthRefreshError = () => {
+    autoRefreshToken(false);
+    setAuthenticatied(false);
+    setCanAdd(false);
+    setCanEdit(false);
+  };
+  keycloak.onAuthRefreshSuccess = () => {
+    setAuthenticatied(true);
 
-      const { roles } = keycloak.realmAccess || [];
-      setCanEdit(roles.includes('bs_all'));
-      setCanAdd(roles.includes('bs_all'));
-    };
-  }, [
-    keycloak.onAuthError,
-    keycloak.onAuthRefreshError,
-    keycloak.onAuthSuccess,
-    keycloak.realmAccess,
-  ]);
+    const { roles } = keycloak.realmAccess || [];
+    setCanEdit(roles.includes('bs_all'));
+    setCanAdd(roles.includes('bs_all'));
+  };
 
   return { authenticated, canAdd, canEdit };
 };


### PR DESCRIPTION
It seems we are sometimes running into a async issue where the login callback comes in before we registered the handlers. By dropping the useEffect method, we *might* prevent that.